### PR TITLE
FIX: out-of-sofa builds without install

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/SofaApplication.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/SofaApplication.cpp
@@ -955,7 +955,9 @@ bool SofaApplication::DefaultMain(QApplication& app, QQmlApplicationEngine &appl
 
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
     app.addLibraryPath(QCoreApplication::applicationDirPath() + "/../lib/");
-    
+    // Necessary for standalone builds (out-of-sofa without install)
+    app.addLibraryPath(QCoreApplication::applicationDirPath() + "/../SofaQtQuickGUI/");
+
     // initialise paths
     SofaApplication::UseDefaultSofaPath();
 


### PR DESCRIPTION
This PR lets runSofa2 find the SofaQtQuickGUI library when compiling the project as a standalone build.
runSofa2 looks for the library in "<applicationDirPath>/../lib", but when building separately from SOFA, the binaries are placed in a directory named after the plugin.

Might not be the cleanest way (?), but it works.