### PR TITLE
Fix: Scene hierarchy view

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/SofaScene.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/SofaScene.cpp
@@ -2058,9 +2058,16 @@ void SofaScene::addChild(Node* parent, Node* child)
     if(!child)
         return;
 
+    onBeginAddChild(parent, child);
+
     myBases.insert(child);
 
-    MutationListener::addChild(parent, child);
+    onEndAddChild(parent, child);
+
+    for(Node::ObjectIterator it = child->object.begin(); it != child->object.end(); ++it)
+        addObject(child, it->get());
+    for(Node::ChildIterator it = child->child.begin(); it != child->child.end(); ++it)
+        addChild(child, it->get());
 }
 
 void SofaScene::removeChild(Node* parent, Node* child)
@@ -2068,7 +2075,10 @@ void SofaScene::removeChild(Node* parent, Node* child)
     if(!child)
         return;
 
-    MutationListener::removeChild(parent, child);
+    for(Node::ObjectIterator it = child->object.begin(); it != child->object.end(); ++it)
+        removeObject(child, it->get());
+    for(Node::ChildIterator it = child->child.begin(); it != child->child.end(); ++it)
+        removeChild(child, it->get());
 
     myBases.remove(child);
 }
@@ -2079,16 +2089,12 @@ void SofaScene::addObject(Node* parent, BaseObject* object)
         return;
 
     myBases.insert(object);
-
-    MutationListener::addObject(parent, object);
 }
 
 void SofaScene::removeObject(Node* parent, BaseObject* object)
 {
     if(!object || !parent)
         return;
-
-    MutationListener::removeObject(parent, object);
 
     myBases.remove(object);
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/SofaScene.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/SofaScene.cpp
@@ -2080,7 +2080,11 @@ void SofaScene::removeChild(Node* parent, Node* child)
     for(Node::ChildIterator it = child->child.begin(); it != child->child.end(); ++it)
         removeChild(child, it->get());
 
+    this->onBeginRemoveChild(parent, child);
+
     myBases.remove(child);
+
+    this->onEndRemoveChild(parent, child);
 }
 
 void SofaScene::addObject(Node* parent, BaseObject* object)
@@ -2088,7 +2092,11 @@ void SofaScene::addObject(Node* parent, BaseObject* object)
     if(!object || !parent)
         return;
 
+    this->onBeginAddObject(parent, object);
+
     myBases.insert(object);
+
+    this->onEndAddObject(parent, object);
 }
 
 void SofaScene::removeObject(Node* parent, BaseObject* object)
@@ -2096,7 +2104,11 @@ void SofaScene::removeObject(Node* parent, BaseObject* object)
     if(!object || !parent)
         return;
 
+    this->onBeginRemoveObject(parent, object);
+
     myBases.remove(object);
+
+    this->onEndRemoveObject(parent, object);
 }
 
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/SofaSceneListModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/SofaSceneListModel.cpp
@@ -468,6 +468,8 @@ void SofaSceneListModel::addChild(Node* parent, Node* child)
     if(!child)
         return;
 
+    this->onBeginAddChild(parent, child);
+
     //std::cerr << "++" << child->getName().c_str() << "(" << child << ")" << " ; " << (parent ? parent->getName().c_str() : "") << "(" << parent << ")" << " > " << std::flush;
 
     if(!parent)
@@ -527,7 +529,13 @@ void SofaSceneListModel::addChild(Node* parent, Node* child)
         }
     }
 
-    MutationListener::addChild(parent, child);
+    this->onEndAddChild(parent, child);
+
+    // recursive behavior
+    for(Node::ObjectIterator it = child->object.begin(); it != child->object.end(); ++it)
+        addObject(child, it->get());
+    for(Node::ChildIterator it = child->child.begin(); it != child->child.end(); ++it)
+        addChild(child, it->get());
 }
 
 void SofaSceneListModel::removeChild(Node* parent, Node* child)
@@ -535,9 +543,15 @@ void SofaSceneListModel::removeChild(Node* parent, Node* child)
     if(!child)
         return;
 
-    MutationListener::removeChild(parent, child);
+    // recursive behavior
+    for(Node::ObjectIterator it = child->object.begin(); it != child->object.end(); ++it)
+        removeObject(child, it->get());
+    for(Node::ChildIterator it = child->child.begin(); it != child->child.end(); ++it)
+        removeChild(child, it->get());
 
     //std::cerr << "--" << child->getName().c_str() << "(" << child << ")" << " ; " << (parent ? parent->getName().c_str() : "") << "(" << parent << ")" << " > " << std::flush;
+
+    this->onBeginRemoveChild(parent, child);
 
     QList<Item>::iterator itemIt = myItems.begin();
     while(itemIt != myItems.end())
@@ -577,6 +591,8 @@ void SofaSceneListModel::removeChild(Node* parent, Node* child)
             ++itemIt;
         }
     }
+
+    this->onEndRemoveChild(parent, child);
 }
 
 //void SceneListModel::moveChild(Node* previous, Node* parent, Node* child)
@@ -590,6 +606,8 @@ void SofaSceneListModel::addObject(Node* parent, BaseObject* object)
         return;
 
     //std::cerr << "+" << object->getName().c_str() << "(" << object << ")" << " ; " << (parent ? parent->getName().c_str() : "") << "(" << parent << ")" << " > " << std::flush;
+
+    this->onBeginAddObject(parent, object);
 
     bool alreadyAdded = false;
     for(auto it = myItems.begin(); it != myItems.end(); ++it)
@@ -633,7 +651,7 @@ void SofaSceneListModel::addObject(Node* parent, BaseObject* object)
         }
     }
 
-    MutationListener::addObject(parent, object);
+    this->onEndAddObject(parent, object);
 }
 
 void SofaSceneListModel::removeObject(Node* parent, BaseObject* object)
@@ -641,7 +659,7 @@ void SofaSceneListModel::removeObject(Node* parent, BaseObject* object)
     if(!object || !parent)
         return;
 
-    MutationListener::removeObject(parent, object);
+    this->onBeginRemoveObject(parent, object);
 
     //std::cerr << "-" << object->getName().c_str() << "(" << object << ")" << " ; " << (parent ? parent->getName().c_str() : "") << "(" << parent << ")" << " > " << std::flush;
 
@@ -683,6 +701,8 @@ void SofaSceneListModel::removeObject(Node* parent, BaseObject* object)
             ++itemIt;
         }
     }
+
+    this->onEndRemoveObject(parent, object);
 }
 
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/SofaSceneListModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/SofaSceneListModel.h
@@ -138,7 +138,6 @@ private:
 private:
     QList<Item>                     myItems;
     SofaScene*                      mySofaScene;
-
 };
 
 }


### PR DESCRIPTION
Dues to changes about the class _MutationListener_ onto the **master** branch of SOFA repository, the SofaQtQuick GUI did not correctly displayed the scene hierarchy view. This PR fixes the issue.