### PR TITLE
Fix a build issue: The module SofaOpenglVisual was not linked

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
+++ b/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
@@ -242,7 +242,7 @@ find_package(SofaFramework REQUIRED)
 find_package(SofaPython REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${MOC_FILES} ${SOURCE_FILES} ${QRC_FILES} ${RESOURCE_FILES} ${QML_FILES} ${CONFIG_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} SofaPython SofaSimulationGraph SofaComponentBase Qt5::Core Qt5::Gui Qt5::Widgets Qt5::QuickControls2 Qt5::Qml Qt5::Quick)
+target_link_libraries(${PROJECT_NAME} SofaPython SofaSimulationGraph SofaComponentBase SofaOpenglVisual Qt5::Core Qt5::Gui Qt5::Widgets Qt5::QuickControls2 Qt5::Qml Qt5::Quick)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")


### PR DESCRIPTION
Fix a build issue: The module SofaOpenglVisual was not linked. Consequently, the plugin did not compile. I simply add the link to the SOFA module into the CMakeList.txt file of SofaQtQuick.